### PR TITLE
Pritunl fix + runit log

### DIFF
--- a/srcpkgs/pritunl-client/files/pritunl-client/log/run
+++ b/srcpkgs/pritunl-client/files/pritunl-client/log/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec logger -t 'pritunl'

--- a/srcpkgs/pritunl-client/files/pritunl-client/run
+++ b/srcpkgs/pritunl-client/files/pritunl-client/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec pritunl-client daemon --foreground

--- a/srcpkgs/pritunl-client/files/pritunl-client/run
+++ b/srcpkgs/pritunl-client/files/pritunl-client/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec pritunl-client daemon --foreground
+exec pritunl-client daemon --foreground 2>&1

--- a/srcpkgs/pritunl-client/template
+++ b/srcpkgs/pritunl-client/template
@@ -1,0 +1,25 @@
+# Template file for 'pritunl-client'
+pkgname=pritunl-client
+version=1.0.1632.81
+revision=1
+build_style=python-module
+pycompile_module="pritunl-client"
+make_install_args="--no-upstart --no-systemd"
+hostmakedepends="python-setuptools"
+depends="python-requests python-crypto pygtk"
+short_desc="OpenVPN Client"
+maintainer="Andrew Benson <abenson+void@gmail.com>"
+license="Proprietary"
+homepage="http://client.pritunl.com/"
+distfiles="https://github.com/pritunl/pritunl-client/archive/${version}.tar.gz"
+checksum=cb6f669fa112ea2bf8aff02cb118282ae8bfc94f8e957c8b80e2700d1f9ee8e9
+noarch=yes
+restricted=yes
+
+post_install() {
+	vsv pritunl-client
+
+	rm -rf ${DESTDIR}/var/log
+
+	vlicense LICENSE
+}

--- a/srcpkgs/pritunl-client/template
+++ b/srcpkgs/pritunl-client/template
@@ -2,7 +2,7 @@
 pkgname=pritunl-client
 version=1.0.1632.81
 revision=1
-build_style=python-module
+build_style=python2-module
 pycompile_module="pritunl-client"
 make_install_args="--no-upstart --no-systemd"
 hostmakedepends="python-setuptools"


### PR DESCRIPTION
Add logging to pritunl daemon, switch build style to python2 so /usr/bin packages don't get renamed.